### PR TITLE
Fixed CD bug

### DIFF
--- a/Aura Operating System/Aura OS/Shell/cmdIntr/FileSystem/CD.cs
+++ b/Aura Operating System/Aura OS/Shell/cmdIntr/FileSystem/CD.cs
@@ -49,6 +49,10 @@ namespace Aura_OS.Shell.cmdIntr.FileSystem
                         Kernel.current_directory = root.mParent.mFullPath;
                     }
                 }
+                else if (dir == @"0:\")
+                { 
+                    Kernel.current_directory = @"0:\";
+                }
                 else
                 {
                     if (Directory.Exists(Kernel.current_directory + dir))


### PR DESCRIPTION
When you did "cd 0:\" before you would get an error. Now you can do it with no error just fine.